### PR TITLE
Custom music player with play/pause for local audio files

### DIFF
--- a/components/MusicPlayer.tsx
+++ b/components/MusicPlayer.tsx
@@ -1,101 +1,141 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { Music, X, ChevronDown, ChevronUp } from "lucide-react";
-
-function toEmbedUrl(input: string): string | null {
-  try {
-    const url = new URL(input.trim());
-    if (!url.hostname.includes("spotify.com")) return null;
-    // e.g. /playlist/abc123 → /embed/playlist/abc123
-    const embedPath = url.pathname.replace(/^\//, "embed/");
-    return `https://open.spotify.com/${embedPath}?utm_source=generator`;
-  } catch {
-    return null;
-  }
-}
+import { useState, useRef, useEffect } from "react";
+import { Music, Play, Pause, Upload, X, SkipBack } from "lucide-react";
 
 export default function MusicPlayer() {
-  const [embedUrl, setEmbedUrl] = useState<string | null>(null);
-  const [input, setInput] = useState("");
-  const [error, setError] = useState(false);
-  const [collapsed, setCollapsed] = useState(false);
+  const [track, setTrack] = useState<{ name: string; url: string } | null>(null);
+  const [playing, setPlaying] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
+  // Clean up object URLs on unmount
   useEffect(() => {
-    const saved = localStorage.getItem("spotify_embed");
-    if (saved) setEmbedUrl(saved);
-  }, []);
+    return () => {
+      if (track?.url.startsWith("blob:")) URL.revokeObjectURL(track.url);
+    };
+  }, [track]);
 
-  function handleLoad() {
-    const url = toEmbedUrl(input);
-    if (!url) { setError(true); return; }
-    setError(false);
-    setEmbedUrl(url);
-    localStorage.setItem("spotify_embed", url);
-    setInput("");
+  function handleFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (track?.url.startsWith("blob:")) URL.revokeObjectURL(track.url);
+    const url = URL.createObjectURL(file);
+    setTrack({ name: file.name.replace(/\.[^.]+$/, ""), url });
+    setPlaying(false);
+    setProgress(0);
   }
 
-  function handleClear() {
-    setEmbedUrl(null);
-    localStorage.removeItem("spotify_embed");
+  function togglePlay() {
+    const audio = audioRef.current;
+    if (!audio) return;
+    if (playing) {
+      audio.pause();
+    } else {
+      audio.play();
+    }
+    setPlaying(!playing);
+  }
+
+  function handleRestart() {
+    const audio = audioRef.current;
+    if (!audio) return;
+    audio.currentTime = 0;
+    setProgress(0);
+  }
+
+  function handleTimeUpdate() {
+    const audio = audioRef.current;
+    if (!audio || !audio.duration) return;
+    setProgress((audio.currentTime / audio.duration) * 100);
+  }
+
+  function handleEnded() {
+    setPlaying(false);
+    setProgress(0);
+  }
+
+  function handleSeek(e: React.MouseEvent<HTMLDivElement>) {
+    const audio = audioRef.current;
+    if (!audio || !audio.duration) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const ratio = (e.clientX - rect.left) / rect.width;
+    audio.currentTime = ratio * audio.duration;
+  }
+
+  function handleRemove() {
+    const audio = audioRef.current;
+    if (audio) { audio.pause(); audio.src = ""; }
+    if (track?.url.startsWith("blob:")) URL.revokeObjectURL(track.url);
+    setTrack(null);
+    setPlaying(false);
+    setProgress(0);
+    if (fileInputRef.current) fileInputRef.current.value = "";
   }
 
   return (
-    <div className="border-t border-warm/60 bg-warm/50">
-      {/* Header */}
-      <button
-        onClick={() => setCollapsed(!collapsed)}
-        className="w-full flex items-center gap-2 px-4 py-3 hover:bg-warm transition-colors"
-      >
-        <Music size={14} className="text-brown-light shrink-0" />
-        <span className="flex-1 text-left text-xs font-semibold text-brown-light">Muziek</span>
-        {collapsed ? <ChevronUp size={14} className="text-brown-light" /> : <ChevronDown size={14} className="text-brown-light" />}
-      </button>
+    <div className="border-t border-warm/60 bg-warm/50 px-3 py-3">
+      <input ref={fileInputRef} type="file" accept="audio/*" className="hidden" onChange={handleFile} />
 
-      {!collapsed && (
-        <div className="px-3 pb-3">
-          {embedUrl ? (
-            <div className="relative">
-              <iframe
-                src={embedUrl}
-                width="100%"
-                height="152"
-                allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-                loading="lazy"
-                className="rounded-2xl"
-              />
-              <button
-                onClick={handleClear}
-                className="absolute top-2 right-2 bg-brown/70 text-cream rounded-full p-1 hover:bg-brown transition-colors"
-                title="Verwijderen"
-              >
-                <X size={10} />
-              </button>
-            </div>
-          ) : (
-            <div className="flex flex-col gap-2">
-              <input
-                value={input}
-                onChange={(e) => { setInput(e.target.value); setError(false); }}
-                onKeyDown={(e) => e.key === "Enter" && handleLoad()}
-                placeholder="Plak een Spotify-link..."
-                className={`w-full bg-cream rounded-xl border px-3 py-2 text-xs text-brown focus:outline-none ${
-                  error ? "border-rose" : "border-warm focus:border-sage"
-                }`}
-              />
-              {error && <p className="text-xs text-rose">Geen geldige Spotify-link</p>}
-              <button
-                onClick={handleLoad}
-                className="w-full bg-[#1DB954] text-white rounded-xl py-1.5 text-xs font-semibold hover:bg-[#1aa34a] transition-colors"
-              >
-                Laden
-              </button>
-              <p className="text-xs text-brown-light text-center leading-tight">
-                Werkt met nummers, afspeellijsten & albums
-              </p>
-            </div>
-          )}
+      {track ? (
+        <div className="flex flex-col gap-2">
+          {/* Track name */}
+          <div className="flex items-center gap-2">
+            <Music size={12} className="text-brown-light shrink-0" />
+            <p className="text-xs text-brown font-semibold truncate flex-1">{track.name}</p>
+            <button onClick={handleRemove} className="text-brown-light hover:text-brown transition-colors">
+              <X size={12} />
+            </button>
+          </div>
+
+          {/* Progress bar */}
+          <div
+            className="w-full h-1.5 bg-cream rounded-full cursor-pointer"
+            onClick={handleSeek}
+          >
+            <div
+              className="h-full bg-terracotta rounded-full transition-all"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+
+          {/* Controls */}
+          <div className="flex items-center justify-center gap-3">
+            <button onClick={handleRestart} className="text-brown-light hover:text-brown transition-colors">
+              <SkipBack size={14} />
+            </button>
+            <button
+              onClick={togglePlay}
+              className="bg-terracotta text-cream rounded-full p-2 hover:bg-terracotta/80 transition-colors"
+            >
+              {playing ? <Pause size={14} /> : <Play size={14} />}
+            </button>
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              className="text-brown-light hover:text-brown transition-colors"
+              title="Ander nummer"
+            >
+              <Upload size={14} />
+            </button>
+          </div>
+
+          <audio
+            ref={audioRef}
+            src={track.url}
+            onTimeUpdate={handleTimeUpdate}
+            onEnded={handleEnded}
+          />
         </div>
+      ) : (
+        <button
+          onClick={() => fileInputRef.current?.click()}
+          className="w-full flex items-center gap-2 py-2 px-3 rounded-2xl border-2 border-dashed border-warm hover:border-sage hover:bg-sage-light/20 transition-all group"
+        >
+          <Music size={14} className="text-brown-light group-hover:text-sage transition-colors shrink-0" />
+          <span className="text-xs text-brown-light group-hover:text-sage transition-colors">Muziek toevoegen</span>
+          <Upload size={12} className="text-brown-light group-hover:text-sage ml-auto transition-colors" />
+        </button>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Removed Spotify embed integration
- New custom audio player in the sidebar — click to upload any audio file from your device
- Play/pause button, restart button, clickable progress bar
- Clean minimal design matching the rest of the site

## Test plan
- [ ] Click "Muziek toevoegen" in the sidebar and pick an audio file
- [ ] Verify play/pause, restart, and progress bar work
- [ ] Click the upload icon to swap to a different track

🤖 Generated with [Claude Code](https://claude.com/claude-code)